### PR TITLE
feat: add mautrix-slack appservice integration

### DIFF
--- a/k8s/appservices-secret.yaml
+++ b/k8s/appservices-secret.yaml
@@ -1,5 +1,20 @@
-# NOTE: Replace tokens with actual values from AWS Secrets Manager
-# aws secretsmanager get-secret-value --secret-id clap-mautrix-slack-tokens-dev
+# ============================================================================
+# WARNING: DO NOT APPLY THIS FILE WITHOUT REPLACING PLACEHOLDER TOKENS!
+# ============================================================================
+#
+# Before applying, replace REPLACE_WITH_AS_TOKEN and REPLACE_WITH_HS_TOKEN
+# with actual values from AWS Secrets Manager:
+#
+#   aws secretsmanager get-secret-value \
+#     --secret-id clap-mautrix-slack-tokens-dev \
+#     --query SecretString --output text | jq .
+#
+# PRODUCTION CONSIDERATIONS:
+# - Set rate_limited: true for production environments
+# - Configure Synapse rc_message rate limits in homeserver.yaml
+# - Run load tests to tune appropriate limits before production deployment
+# - Consider using External Secrets Operator for automated secret rotation
+# ============================================================================
 apiVersion: v1
 kind: Secret
 metadata:
@@ -23,4 +38,4 @@ stringData:
           exclusive: true
     sender_localpart: slackbot
     url: "http://mautrix-slack.dev.svc.cluster.local:29335"
-    rate_limited: false
+    rate_limited: false  # Set to true for production

--- a/k8s/appservices-secret.yaml
+++ b/k8s/appservices-secret.yaml
@@ -1,0 +1,26 @@
+# NOTE: Replace tokens with actual values from AWS Secrets Manager
+# aws secretsmanager get-secret-value --secret-id clap-mautrix-slack-tokens-dev
+apiVersion: v1
+kind: Secret
+metadata:
+  name: synapse-appservices-tokens
+  namespace: dev
+type: Opaque
+stringData:
+  mautrix-slack-registration.yaml: |
+    id: slack
+    as_token: "REPLACE_WITH_AS_TOKEN"
+    hs_token: "REPLACE_WITH_HS_TOKEN"
+    namespaces:
+      rooms: []
+      users:
+        - regex: "@slack_.*:dev.clap.ac"
+          exclusive: true
+        - regex: "@slackbot:dev.clap.ac"
+          exclusive: true
+      aliases:
+        - regex: "#slack_.+:dev.clap.ac"
+          exclusive: true
+    sender_localpart: slackbot
+    url: "http://mautrix-slack.dev.svc.cluster.local:29335"
+    rate_limited: false

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -16,5 +16,5 @@ data:
   # Note: Variable name must match homeserver.yaml template (S3_BUCKET_NAME)
   S3_BUCKET_NAME: "clap-messenger-media-dev-619888520513"
   # Application Services (bridges)
-  # Comma-separated list of registration file paths
-  SYNAPSE_APPSERVICES: "/data/appservices/mautrix-slack-registration.yaml"
+  # Note: start.py auto-discovers registration files from /conf/appservices/*.yaml
+  # Mount appservice secrets to /conf/appservices directory

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -15,3 +15,6 @@ data:
   # S3 Storage Provider configuration
   # Note: Variable name must match homeserver.yaml template (S3_BUCKET_NAME)
   S3_BUCKET_NAME: "clap-messenger-media-dev-619888520513"
+  # Application Services (bridges)
+  # Comma-separated list of registration file paths
+  SYNAPSE_APPSERVICES: "/data/appservices/mautrix-slack-registration.yaml"

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -76,6 +76,9 @@ spec:
         volumeMounts:
         - name: data
           mountPath: /data
+        - name: appservices
+          mountPath: /data/appservices
+          readOnly: true
 
         livenessProbe:
           httpGet:
@@ -99,3 +102,6 @@ spec:
       - name: data
         persistentVolumeClaim:
           claimName: synapse-efs-pvc
+      - name: appservices
+        secret:
+          secretName: synapse-appservices-tokens

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -77,7 +77,7 @@ spec:
         - name: data
           mountPath: /data
         - name: appservices
-          mountPath: /data/appservices
+          mountPath: /conf/appservices
           readOnly: true
 
         livenessProbe:


### PR DESCRIPTION
## Summary
- Synapse에 mautrix-slack appservice 연동 추가
- EKS 환경에서 mautrix-slack 브릿지 사용 가능

## Changes
- `k8s/configmap.yaml` - SYNAPSE_APPSERVICES 환경변수 추가
- `k8s/deployment.yaml` - appservices Secret 볼륨 마운트 추가
- `k8s/appservices-secret.yaml` - mautrix-slack registration Secret (신규)

## Test plan
- [ ] Secret에 실제 토큰 값 입력
- [ ] kubectl apply 후 Synapse 재시작 확인
- [ ] mautrix-slack 브릿지 연동 테스트

## Dependencies
- clap-infrastructure#38 (mautrix-slack EKS 마이그레이션) 먼저 적용 필요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Slack 브릿지 통합을 위한 애플리케이션 서비스 구성 추가
  * 앱서비스 시크릿(토큰) 지원 및 컨테이너 내 읽기 전용 마운트 기능 추가
* **문서**
  * 설정 맵에 앱서비스 등록 경로 및 관련 설명 주석 추가
  * 시크릿 관련 교체/운영(레이트 제한, 로테이션) 권장 사항 주석 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->